### PR TITLE
Make compatible with node 12 and 16 frontend

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -159,7 +159,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
-        run: yarn install && yarn add serve
+        run: pwd && ls && yarn install && yarn add serve
         working-directory: ./${{ inputs.frontendRepo }}
         env:
           REACT_APP_ENV: ${{ inputs.frontendEnvironment }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -160,7 +160,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
-        run: yarn install && yarn global add serve
+        run: yarn install && yarn add serve
         working-directory: ./${{ inputs.frontendRepo }}
         env:
           REACT_APP_ENV: ${{ inputs.frontendEnvironment }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -160,7 +160,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
-        run: yarn install && yarn add serve
+        run: yarn install && yarn global add serve
         working-directory: ./${{ inputs.frontendRepo }}
         env:
           REACT_APP_ENV: ${{ inputs.frontendEnvironment }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -155,10 +155,11 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 16.15.0
+          cache: 'yarn'
 
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
-        run: npm install yarn && yarn install && yarn add serve
+        run: yarn install && yarn add serve
         working-directory: ./${{ inputs.frontendRepo }}
         env:
           REACT_APP_ENV: ${{ inputs.frontendEnvironment }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -150,7 +150,7 @@ jobs:
           path: ${{ inputs.frontendRepo }}
           token: ${{ secrets.token }}
 
-      - name: Use Node.js 16.15.0
+      - name: Use Node.js
         if: steps.cache.outputs.cache-hit != 'true'
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -154,13 +154,13 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         uses: actions/setup-node@v2
         with:
-          node-version: 16.15.0
           cache: 'yarn'
           cache-dependency-path: './${{ inputs.frontendRepo }}/yarn.lock'
+          node-version-file: './${{ inputs.frontendRepo }}/.nvmrc'
 
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
-        run: pwd && ls && yarn install && yarn add serve
+        run: yarn install && yarn add serve
         working-directory: ./${{ inputs.frontendRepo }}
         env:
           REACT_APP_ENV: ${{ inputs.frontendEnvironment }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -156,6 +156,7 @@ jobs:
         with:
           node-version: 16.15.0
           cache: 'yarn'
+          cache-dependency-path: './${{ inputs.frontendRepo }}/yarn.lock'
 
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -428,6 +428,11 @@ jobs:
       - name: Start frontend
         run: yarn serve -s build -l 3000 & npx wait-on http://localhost:3000
         working-directory: ./${{ inputs.frontendRepo }}
+        
+      - name: Change node version to 12.18.0
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12.18.0
 
       # Install dependencies and run all Cypress tests
       - name: Cypress run

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -150,11 +150,11 @@ jobs:
           path: ${{ inputs.frontendRepo }}
           token: ${{ secrets.token }}
 
-      - name: Use Node.js 12.18.0
+      - name: Use Node.js 16.15.0
         if: steps.cache.outputs.cache-hit != 'true'
         uses: actions/setup-node@v2
         with:
-          node-version: 12.18.0
+          node-version: 16.15.0
 
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -420,10 +420,10 @@ jobs:
         env:
           TOGETHER_ENVIRONMENT: ${{ inputs.backendEnvironment }}
 
-      - name: Change node version to 12.18.0
+      - name: Change to frontend node version
         uses: actions/setup-node@v2
         with:
-          node-version: 12.18.0
+          node-version-file: './${{ inputs.frontendRepo }}/.nvmrc'
 
       - name: Start frontend
         run: yarn serve -s build -l 3000 & npx wait-on http://localhost:3000


### PR DESCRIPTION
Uses the `node-version-file` argument for the node action to automatically detect what node version to use for the front end. 

Replaces the `npm install yarn` command with the built in yarn functionality of setup-node. This fixes some errors I was seeing around peer dependencies when installing on node 16. 

Sample PRs of both Node 12 and 16 using this branch and passing: 
https://github.com/together-platform/mentoring-frontend/pull/2878
https://github.com/together-platform/mentoring-frontend/pull/2876