### PR TITLE
Use Node version from .nvmrc

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -436,7 +436,7 @@ jobs:
       - name: Change to e2e node version
         uses: actions/setup-node@v2
         with:
-          node-version-file: './${{ inputs.backendMentoringRepo }}/.nvmrc'
+          node-version-file: './${{ inputs.e2eTestsRepo }}/.nvmrc'
 
       # Install dependencies and run all Cypress tests
       - name: Cypress run

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -309,8 +309,8 @@ jobs:
         uses: actions/setup-node@v2
         with:
           cache: 'yarn'
-          cache-dependency-path: './${{ inputs.backendMentoringRepo }}/yarn.lock'
-          node-version-file: './${{ inputs.backendMentoringRepo }}/.nvmrc'
+          cache-dependency-path: './${{ inputs.e2eTestsRepo }}/yarn.lock'
+          node-version-file: './${{ inputs.e2eTestsRepo }}/.nvmrc'
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -308,6 +308,8 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         uses: actions/setup-node@v2
         with:
+          cache: 'yarn'
+          cache-dependency-path: './${{ inputs.backendMentoringRepo }}/yarn.lock'
           node-version-file: './${{ inputs.backendMentoringRepo }}/.nvmrc'
 
       - name: Install dependencies

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
-        run: yarn install
+        run: yarn install --frozen-lockfile
         working-directory: ./${{ inputs.backendMentoringRepo }}
 
       - name: Set cache
@@ -162,7 +162,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
-        run: yarn install && yarn add serve
+        run: yarn install --frozen-lockfile && yarn add serve
         working-directory: ./${{ inputs.frontendRepo }}
         env:
           REACT_APP_ENV: ${{ inputs.frontendEnvironment }}
@@ -313,7 +313,7 @@ jobs:
           node-version-file: './${{ inputs.backendMentoringRepo }}/.nvmrc'
 
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile
         if: steps.cache.outputs.cache-hit != 'true'
         working-directory: ./${{ inputs.e2eTestsRepo }}
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -311,7 +311,7 @@ jobs:
           node-version-file: './${{ inputs.backendMentoringRepo }}/.nvmrc'
 
       - name: Install dependencies
-        run: npm install
+        run: yarn install
         if: steps.cache.outputs.cache-hit != 'true'
         working-directory: ./${{ inputs.e2eTestsRepo }}
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -85,15 +85,17 @@ jobs:
           path: ${{ inputs.backendMentoringRepo }}
           token: ${{ secrets.token }}
 
-      - name: Use Node.js 12.16.1
+      - name: Use Node.js
         if: steps.cache.outputs.cache-hit != 'true'
         uses: actions/setup-node@v2
         with:
-          node-version: 12.16.1
+          cache: 'yarn'
+          cache-dependency-path: './${{ inputs.backendMentoringRepo }}/yarn.lock'
+          node-version-file: './${{ inputs.backendMentoringRepo }}/.nvmrc'
 
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
-        run: npm install yarn && yarn install
+        run: yarn install
         working-directory: ./${{ inputs.backendMentoringRepo }}
 
       - name: Set cache
@@ -345,11 +347,6 @@ jobs:
       organizationId: ${{ steps.create_org_for_tests.outputs.organizationId }}
 
     steps:
-      - name: Use Node.js 12.16.1
-        uses: actions/setup-node@v2
-        with:
-          node-version: 12.16.1
-
       - name: Set up Python 3.7.5
         uses: actions/setup-python@v2
         with:
@@ -399,6 +396,11 @@ jobs:
         with:
           path: ~/.cache/Cypress
           key: ${{ inputs.e2eTestsRepo }}-dependencies-${{needs.e2e-tests-prepare.outputs.commit}}
+
+      - name: Use backend Node.js version
+        uses: actions/setup-node@v2
+        with:
+          node-version-file: './${{ inputs.backendMentoringRepo }}/.nvmrc'
 
       - name: Start ${{ inputs.backendPairingRepo }}
         run: make start & npx wait-on http://localhost:9000/pairing/_release
@@ -484,10 +486,10 @@ jobs:
           service_account_key: ${{ secrets.gcp }}
           export_default_credentials: true
 
-      - name: Use Node.js 12.16.1
+      - name: Use Mentoring Service Node.js Version
         uses: actions/setup-node@v2
         with:
-          node-version: 12.16.1
+          node-version-file: './${{ inputs.backendMentoringRepo }}/.nvmrc'
 
       - name: Delete org created for testing
         run: yarn babel-node --extensions ".ts,.js" lib/scripts/deleteDemoOrg/deleteDemoOrg.js ${{needs.start-servers-and-tests.outputs.organizationId}}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -304,11 +304,11 @@ jobs:
           path: ${{ inputs.e2eTestsRepo }}
           token: ${{ secrets.token }}
 
-      - name: Use Node.js 12.18.0
+      - name: Use Node.js
         if: steps.cache.outputs.cache-hit != 'true'
         uses: actions/setup-node@v2
         with:
-          node-version: 12.18.0
+          node-version-file: './${{ inputs.backendMentoringRepo }}/.nvmrc'
 
       - name: Install dependencies
         run: npm install
@@ -431,10 +431,10 @@ jobs:
         run: yarn serve -s build -l 3000 & npx wait-on http://localhost:3000
         working-directory: ./${{ inputs.frontendRepo }}
         
-      - name: Change node version to 12.18.0
+      - name: Change to e2e node version
         uses: actions/setup-node@v2
         with:
-          node-version: 12.18.0
+          node-version-file: './${{ inputs.backendMentoringRepo }}/.nvmrc'
 
       # Install dependencies and run all Cypress tests
       - name: Cypress run

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -397,16 +397,16 @@ jobs:
           path: ~/.cache/Cypress
           key: ${{ inputs.e2eTestsRepo }}-dependencies-${{needs.e2e-tests-prepare.outputs.commit}}
 
-      - name: Use backend Node.js version
-        uses: actions/setup-node@v2
-        with:
-          node-version-file: './${{ inputs.backendMentoringRepo }}/.nvmrc'
-
       - name: Start ${{ inputs.backendPairingRepo }}
         run: make start & npx wait-on http://localhost:9000/pairing/_release
         working-directory: ./${{ inputs.backendPairingRepo }}
         env:
           TOGETHER_ENVIRONMENT: ${{ inputs.backendEnvironment }}
+
+      - name: Use backend Node.js version
+        uses: actions/setup-node@v2
+        with:
+          node-version-file: './${{ inputs.backendMentoringRepo }}/.nvmrc'
 
       - name: Start ${{ inputs.backendMentoringRepo }}
         run: yarn start-production & npx wait-on http://localhost:8080/mentoring/_release


### PR DESCRIPTION
In this previous PR: #7 , we made it so that the Node.js version was pulled from the frontend repo's `.nvmrc` file. This PR does the same for the:

- `mentoring-service`
- `e2e-testing`

repos.

It also fixes some bugs in the workflows:

- We were using `npm install` instead of `yarn install` in e2e-testing repo
- Added `--frozen-lockfile` to `yarn install` to catch uncommitted lockfile changes

Tested this out in mentoring-service:

- With version change: https://github.com/together-platform/mentoring-service/pull/2931
- Without version change: https://github.com/together-platform/mentoring-service/pull/2933